### PR TITLE
Fix bug in scrape example

### DIFF
--- a/scrape_example.py
+++ b/scrape_example.py
@@ -61,6 +61,7 @@ frame = extract_data(play_by_play_url(game_id))
 
 substitutionsOnly = frame[frame["EVENTMSGTYPE"] == 8][['PERIOD', 'EVENTNUM', 'PLAYER1_ID', 'PLAYER2_ID']]
 substitutionsOnly.columns = ['PERIOD', 'EVENTNUM', 'OUT', 'IN']
+substitutionsOnly['EVENTNUM'] = substitutionsOnly.index
 
 subs_in = split_subs(substitutionsOnly, 'IN')
 subs_out = split_subs(substitutionsOnly, 'OUT')


### PR DESCRIPTION
I was using this code to do some analysis and realized I kept getting weird results for some games related to in the incorrect players being set as the starters for a quarter. It turns out that the EVENTNUM provided by the endpoint is not guaranteed to be in the correct order and sometimes an event with a higher EVENTNUM actually happens before an event with lower value. 

For example game_id=0021900882 was the first time I noticed this as Dennis Schroder kept showing up as not starting the 2nd Q (leaving OKC with 4 Q2 starters) b/c the EVENTNUM for his sub IN event was lower than his OUT even though he actually subbed out first.

Anyways this is the fix I made in my code and I think it might be useful in case any pour soul stumbles across this in the future and wastes hours pulling their hair out.